### PR TITLE
removedevbuild: Removed the build on dev branch

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -1,7 +1,7 @@
 on:
     push:
         branches:
-            - dev
+            - topic/*
         paths-ignore:
         - README.md
         - CHANGELOG.md

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -3,9 +3,16 @@ on:
         branches:
             - topic/*
         paths-ignore:
-        - README.md
-        - CHANGELOG.md
-        - .grenrc.yml
+          - README.md
+          - CHANGELOG.md
+          - .grenrc.yml
+    pull_request:
+        branches:
+          - master
+        paths-ignore:
+          - README.md
+          - CHANGELOG.md
+          - .grenrc.yml
 
 name: DevelopmentBuild
 jobs:

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -1,11 +1,4 @@
 on:
-    push:
-        branches:
-            - topic/*
-        paths-ignore:
-          - README.md
-          - CHANGELOG.md
-          - .grenrc.yml
     pull_request:
         branches:
           - master

--- a/compile.sh
+++ b/compile.sh
@@ -21,14 +21,18 @@ updateversion() {
 		echo "GITHUB_REF=$GITHUB_REF"
         GIT_TYPE=$(echo $GITHUB_REF | awk -F '/' '{print $2'})
         GIT_TAG=$(echo $GITHUB_REF | awk -F '/' '{print $3'})
+        GIT_BRANCH=$(echo $GITHUB_REF | awk -F '/' '{print $4'})
         SHORTSHA=$(echo $GITHUB_SHA | cut -c 1-7)
         VERSION=$(echo $VERSION | awk -F - '{print $1}')
         if [ "$GIT_TYPE" == "heads" -a "$GIT_TAG" == "master" ]; then
             echo "Refusing to build an untagged master build. Release builds on a tag only!"
             exit 1
         fi
-        if [ "$GIT_TYPE" == "heads" -a "$GIT_TAG" == "dev" ]; then
-            VERSION="$VERSION-beta-$SHORTSHA"
+        if [ "$GIT_TYPE" == "heads" -a "$GIT_TAG" == "topic" ]; then
+            if [ -z "$GIT_BRANCH" ]; then
+                GIT_BRANCH=beta
+            fi
+            VERSION="$VERSION-$GIT_BRANCH-$SHORTSHA"
         fi
         if [ "$GIT_TYPE" == "tags" ]; then
             VERNO=$(echo $GIT_TAG | awk -F '-' '{print $1}')


### PR DESCRIPTION
Removed the build on the dev branch. All branches to be named topic/blabla and we only do a development build on a PR. This removes the need for a constant dev branch to stick around. Work is done on topic branches. This change affects the GitHub actions only.